### PR TITLE
fix: change default values for master and node policies

### DIFF
--- a/examples/policies/dummy_ssh_private
+++ b/examples/policies/dummy_ssh_private
@@ -1,0 +1,1 @@
+This should be your private ssh key.

--- a/examples/policies/main.tf
+++ b/examples/policies/main.tf
@@ -1,0 +1,32 @@
+module "k8s" {
+  source                  = "../../"
+  iam_role_name           = "iam-role"
+  name                    = "name"
+  state_store_bucket_name = aws_s3_bucket.state-store.id
+  region                  = "eu-west-1"
+  vpc_id                  = "vpc-123"
+  private_subnet_ids      = { "a" : "subnet-123" }
+  public_subnet_ids       = { "a" : "subnet-987", "b" : "subnet-654" }
+  admin_ssh_key           = "./dummy_ssh_private"
+  dns_zone                = "test.com"
+  master_policies = [
+    local.master_policy_some_bucket_access
+  ]
+}
+
+resource "aws_s3_bucket" "state-store" {
+  bucket = "state-store"
+  acl    = "public-read"
+}
+
+locals {
+  master_policy_some_bucket_access = {
+    Effect : "Allow",
+    Action : [
+      "s3:GetObject"
+    ],
+    Resource : [
+      "arn:aws:s3:::some-bucket/*"
+    ]
+  }
+}

--- a/examples/policies/provider.tf
+++ b/examples/policies/provider.tf
@@ -1,0 +1,27 @@
+provider "kops" {
+  state_store = "s3://state-store"
+}
+
+provider "aws" {
+  skip_requesting_account_id  = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  s3_force_path_style         = true
+  region                      = "eu-west-1"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+terraform {
+  required_providers {
+    kops = {
+      source  = "eddycharly/kops"
+      version = "1.21.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/k8s.tf
+++ b/k8s.tf
@@ -88,8 +88,8 @@ resource "kops_cluster" "k8s" {
   ]
 
   additional_policies = {
-    master = jsonencode(local.master_policies)
-    node   = jsonencode(local.node_policies)
+    master = length(local.master_policies) == 0 ? null : jsonencode(local.master_policies)
+    node   = length(local.node_policies) == 0 ? null : jsonencode(local.node_policies)
   }
 
   iam {

--- a/vars.tf
+++ b/vars.tf
@@ -113,13 +113,13 @@ variable "iam_role_name" {
 
 variable "master_policies" {
   type        = any
-  default     = null
+  default     = []
   description = "Additional master policies, https://kops.sigs.k8s.io/iam_roles/#adding-additional-policies"
 }
 
 variable "node_policies" {
   type        = any
-  default     = null
+  default     = []
   description = "Additional node policies, https://kops.sigs.k8s.io/iam_roles/#adding-additional-policies"
 }
 


### PR DESCRIPTION
This fixes the nice nil pointer dereference in kOps provider