### PR TITLE
add support for multiple secrets

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -182,8 +182,12 @@ resource "kops_cluster" "k8s" {
     enable_aws_oidc_provider = var.aws_oidc_provider
   }
 
-  secrets {
-    docker_config = var.docker_config
+  dynamic "secrets" {
+    for_each = local.secrets
+
+    content {
+      docker_config = var.docker_config
+    }
   }
 
   addons {

--- a/locals.tf
+++ b/locals.tf
@@ -58,6 +58,8 @@ locals {
   node_group_subnet_prefix = local.private_subnets_enabled ? "private-${var.region}" : "utility-${var.region}"
   topology                 = local.private_subnets_enabled ? "private" : "public"
   master_subnets_zones     = local.private_subnets_enabled ? keys(var.private_subnet_ids) : slice(keys(var.public_subnet_ids), 0, var.master_count)
+
+  secrets = (length(compact([var.docker_config])) > 0) ? [""] : []
 }
 
 data "aws_s3_bucket" "state_store" {


### PR DESCRIPTION
Terraform removes 'emtpy' secrets in its state so it tries to recreate on each apply.
This will make sure we only render the 'secrets' block if we have at least one
non-empty secret variable.
Supporting CustomCAs #4  will be the next usecase, just adding another 'var' to the compact function