### PR TITLE
exports node group name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "node_security_group_name" {
+  value = "nodes.${var.name}"
+}


### PR DESCRIPTION
Rationale: probably better to calculate the name of the node group created
but kops here instead of relying on the calles to actually know how to
determine the name