### PR TITLE
feat: allow access to instances using session manager

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -195,6 +195,16 @@ resource "kops_cluster" "k8s" {
   addons {
     manifest = "s3://${var.bucket_state_store.id}/${var.name}-addons/addon.yaml"
   }
+
+  external_policies {
+    key   = "master"
+    value = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  }
+
+  external_policies {
+    key   = "node"
+    value = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+  }
 }
 
 resource "kops_instance_group" "masters" {


### PR DESCRIPTION
Enable SSM Agent for masters and nodes by attaching the IAM policy as external policy