### PR TITLE
feat: support for setting ALB TLS Policy

### DIFF
--- a/addons/default-ingress.yaml
+++ b/addons/default-ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/group.name: default
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/ssl-policy: '${ ssl_policy }'
+    alb.ingress.kubernetes.io/actions.response-200: >
+      {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"200","messageBody":"Default"}}
+  name: default-ingress
+spec:
+  rules:
+    - host: '${ host }'
+      http:
+        paths:
+          - path: /
+            backend:
+              service:
+                name: response-200
+                port:
+                  name: use-annotation
+            pathType: Prefix
+  tls:
+    - hosts:
+        - '${ host }'

--- a/default_ingress.tf
+++ b/default_ingress.tf
@@ -1,0 +1,10 @@
+locals {
+  default_ingress = [{
+    name    = "default_ingress"
+    version = "1.0"
+    content = templatefile("${path.module}/addons/default-ingress.yaml", {
+      ssl_policy : var.alb_ssl_policy != null ? var.alb_ssl_policy : "",
+      host : "default--ingress.${var.dns_zone}"
+    })
+  }]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -46,8 +46,9 @@ locals {
 
   addons = flatten([
     var.extra_addons, [
-      local.default_request_adder
-    ], var.external_cluster_autoscaler ? module.cluster_autoscaler.addons : []
+      local.default_request_adder,
+    ], var.external_cluster_autoscaler ? module.cluster_autoscaler.addons : [],
+    var.alb_ssl_policy != null ? local.default_ingress : []
   ])
   addons_yaml = templatefile("${path.module}/addons/addons.yaml.tpl", {
     addons = local.addons

--- a/vars.tf
+++ b/vars.tf
@@ -225,3 +225,9 @@ variable "networking_cni" {
   default     = "calico"
   description = "Which CNI provider to use, supported values are 'calico' and 'cilium'"
 }
+
+variable "alb_ssl_policy" {
+  type        = string
+  default     = null
+  description = "SSL policy to use for ALB, https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#ssl-policy"
+}


### PR DESCRIPTION
Add a variable to set the ALB Ingress TLS policy. If not set the default value will be used.
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#ssl-policy

Note that the alb.ingress.kubernetes.io/ssl-policy annotation must be the same for _all_ ingresses in the
cluster. This feature will create a default ingress with the wanted policy to avoid updating all ingressess
when changing the policy