### PR TITLE
feat: migrate to clayrisser/kops

### DIFF
--- a/examples/additional_nodes/provider.tf
+++ b/examples/additional_nodes/provider.tf
@@ -15,8 +15,8 @@ provider "aws" {
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "1.25.3"
+      source  = "clayrisser/kops"
+      version = "1.28.0"
     }
 
     aws = {

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -15,8 +15,8 @@ provider "aws" {
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "1.25.3"
+      source  = "clayrisser/kops"
+      version = "1.28.0"
     }
 
     aws = {

--- a/examples/policies/provider.tf
+++ b/examples/policies/provider.tf
@@ -15,8 +15,8 @@ provider "aws" {
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "1.25.3"
+      source  = "clayrisser/kops"
+      version = "1.28.0"
     }
 
     aws = {

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  master_policies_aws_loadbalancer = {
+  control_plane_policies_aws_loadbalancer = {
     Action = [
       "acm:ListCertificates",
       "acm:DescribeCertificate",
@@ -7,7 +7,7 @@ locals {
     Effect   = "Allow"
     Resource = "*"
   }
-  master_policy_addon_bucket_access = {
+  control_plane_policy_addon_bucket_access = {
     Effect : "Allow",
     Action : [
       "s3:GetObject"
@@ -16,9 +16,10 @@ locals {
       "${var.bucket_state_store.arn}/${var.name}-addons/*"
     ]
   }
-  master_policies = flatten([
-    local.master_policies_aws_loadbalancer,
-    local.master_policy_addon_bucket_access,
+  control_plane_policies = flatten([
+    local.control_plane_policies_aws_loadbalancer,
+    local.control_plane_policy_addon_bucket_access,
+    var.control_plane_policies,
     var.master_policies
     ]
   )
@@ -56,7 +57,6 @@ locals {
 
   private_subnets_enabled  = length(var.private_subnet_ids) > 0
   node_group_subnet_prefix = local.private_subnets_enabled ? "private-${var.region}" : "utility-${var.region}"
-  topology                 = local.private_subnets_enabled ? "private" : "public"
   master_subnets_zones     = local.private_subnets_enabled ? slice(keys(var.private_subnet_ids), 0, var.master_count) : slice(keys(var.public_subnet_ids), 0, var.master_count)
 
   min_nodes               = tomap({ for k, v in var.public_subnet_ids : k => lookup(var.node_size, k, local.min_max_node_default).min })

--- a/providers.tf
+++ b/providers.tf
@@ -5,8 +5,8 @@ terraform {
       version = "~> 5.0"
     }
     kops = {
-      source  = "eddycharly/kops"
-      version = "~> 1.25.3"
+      source  = "clayrisser/kops"
+      version = "1.28.0"
     }
   }
   required_version = ">= 1.3.0"

--- a/vars.tf
+++ b/vars.tf
@@ -166,10 +166,16 @@ variable "iam_role_mappings" {
   description = "The IAM role arn that will be allowed access with a ClusterRole to the Kubernetes cluster. Mapping from IAM ARN => Kubernetes ClusterRole"
 }
 
+variable "control_plane_policies" {
+  type        = any
+  default     = []
+  description = "Additional control plane policies, https://kops.sigs.k8s.io/iam_roles/#adding-additional-policies"
+}
+
 variable "master_policies" {
   type        = any
   default     = []
-  description = "Additional master policies, https://kops.sigs.k8s.io/iam_roles/#adding-additional-policies"
+  description = "Deprecated, use control_plane_policies instead."
 }
 
 variable "node_policies" {
@@ -249,4 +255,10 @@ variable "alb_ssl_policy" {
   type        = string
   default     = null
   description = "SSL policy to use for ALB, https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#ssl-policy"
+}
+
+variable "control_plane_prefix" {
+  type        = string
+  default     = "control-plane"
+  description = "Prefix of control plane instance groups"
 }


### PR DESCRIPTION
BREAKING: Requires a terraform state rm + terraform import of the kops_cluster resource due to incompatible state formats.