### PR TITLE
feat: disable kubelet anonymous auth

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -201,6 +201,9 @@ resource "kops_cluster" "k8s" {
   }
 
   kubelet {
+    anonymous_auth {
+      value = false
+    }
   }
 
   metrics_server {


### PR DESCRIPTION
Kubelet anonymousAuth is currently turned on. This allows RBAC escalation and remote code execution possibilities. It is highly recommended you turn it off by setting '\''spec.kubelet.anonymousAuth'\'' to '\''false'\'' via '\''kops edit cluster'\''

See https://kops.sigs.k8s.io/security/#kubelet-api