### PR TITLE
chore(dependabot): simplify terraform directories configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: terraform
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: terraform
-    directory: "/examples"
+    directories:
+    - "/"
+    - "**/*"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Consolidate the directories for the Terraform package ecosystem in the 
Dependabot configuration. The change enhances clarity by allowing 
multiple directories to be specified in a single entry, reducing 
redundancy and improving maintainability of the file.