### PR TITLE
refactor: update label to use standardized naming convention

### DIFF
--- a/addons/default-request-adder.yaml
+++ b/addons/default-request-adder.yaml
@@ -39,14 +39,14 @@ metadata:
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   labels:
-    app: default-request-adder
+    app.kubernetes.io/name: default-request-adder
   name: default-request-adder
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: default-request-adder
+      app.kubernetes.io/name: default-request-adder
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -55,7 +55,7 @@ spec:
   template:
     metadata:
       labels:
-        app: default-request-adder
+        app.kubernetes.io/name: default-request-adder
     spec:
       serviceAccountName: default-request-adder
       containers:


### PR DESCRIPTION
Changes the label from `app` to `app.kubernetes.io/name` in the 
default-request-adder configuration. This update ensures 
adherence to Kubernetes best practices for labeling, which 
improves resource identification and management within the 
cluster.