### PR TITLE
chore: update required version and Kubernetes version

### DIFF
--- a/examples/additional_nodes/main.tf
+++ b/examples/additional_nodes/main.tf
@@ -1,7 +1,7 @@
 module "k8s" {
   source             = "../../"
   name               = "name"
-  kubernetes_version = "1.23.6"
+  kubernetes_version = "1.31.4"
   bucket_state_store = aws_s3_bucket.state-store
   region             = "eu-west-1"
   vpc_id             = "vpc-123"

--- a/examples/additional_nodes/provider.tf
+++ b/examples/additional_nodes/provider.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,7 @@
 module "k8s" {
   source             = "../../"
   name               = "name"
-  kubernetes_version = "1.23.6"
+  kubernetes_version = "1.31.4"
   bucket_state_store = aws_s3_bucket.state-store
   region             = "eu-west-1"
   vpc_id             = "vpc-123"

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 }

--- a/examples/policies/main.tf
+++ b/examples/policies/main.tf
@@ -1,7 +1,7 @@
 module "k8s" {
   source             = "../../"
   name               = "name"
-  kubernetes_version = "1.23.6"
+  kubernetes_version = "1.31.4"
   bucket_state_store = aws_s3_bucket.state-store
   region             = "eu-west-1"
   vpc_id             = "vpc-123"

--- a/examples/policies/provider.tf
+++ b/examples/policies/provider.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 3.2"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update the required Terraform version from ">= 1.3.0" to ">= 1.3" across  
multiple provider and module files for consistency. Upgrade the  
Kubernetes version from "1.23.6" to "1.31.4" in example modules to  
ensure compatibility with newer features and improvements.