### PR TITLE
chore(commitlint): increase header max length to 105 chars

### DIFF
--- a/.github/commitlint.config.mjs
+++ b/.github/commitlint.config.mjs
@@ -4,6 +4,7 @@ export default {
    * Any rules defined here will override rules from @commitlint/config-conventional
    */
   rules: {
+    'header-max-length': [2, 'always', 105],
     'body-max-line-length': [2, 'always', 200],
   },
 };


### PR DESCRIPTION
Adjusts the header-max-length rule to allow a maximum of 105 
characters for commit messages. This change aims to enhance 
flexibility in commit message formatting while maintaining 
readability.