### PR TITLE
feat: add default_request_adder with excluded namespaces

### DIFF
--- a/addons/default-request-adder.yaml
+++ b/addons/default-request-adder.yaml
@@ -15,8 +15,11 @@ rules:
     verbs: [ "list" ]
   - apiGroups: [ "" ]
     resources: [ "limitranges" ]
-    verbs: [ "list","create" ]
-
+    verbs: [ "list", "create" ]
+  - apiGroups: [ "" ]
+    resources: [ "limitranges" ]
+    resourceNames: [ "extreme-request-defaults" ]
+    verbs: [ "delete" ]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -69,6 +72,6 @@ spec:
           image: registry.gitlab.com/unboundsoftware/default-request-adder:1.2.1@sha256:f2d57e96d7ade865740d93143f29efd64eee34aa180129e9cba16901ca058e51
           args:
             - /default-request-adder
-            - -excluded-ns=kube-system
+            - -excluded-ns=${ excluded_namespaces }
             - -memory=1Pi
       restartPolicy: Always

--- a/default_request_adder.tf
+++ b/default_request_adder.tf
@@ -1,0 +1,11 @@
+locals {
+  default_request_adder = [{
+    name = "default_request_adder"
+    # renovate: datasource=gitlab-releases depName=unboundsoftware/default-request-adder
+    version = "1.2.1"
+    content = templatefile("${path.module}/addons/default-request-adder.yaml", {
+      excluded_namespaces = join(",", distinct(flatten([["kube-system"], local.excluded_trimmed])))
+    })
+  }]
+  excluded_trimmed = [for ns in var.default_request_adder_excluded_namespaces : trimspace(ns)]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -39,12 +39,6 @@ locals {
     }
   ] : [])
 
-  default_request_adder = {
-    name = "default_request_adder"
-    # renovate: datasource=gitlab-releases depName=unboundsoftware/default-request-adder
-    version = "1.2.1"
-    content = file("${path.module}/addons/default-request-adder.yaml")
-  }
 
   addons = flatten([
     var.extra_addons, [

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
       "customType": "regex",
       "description": "Update version variables in tf-files",
       "managerFilePatterns": [
-        "/^locals.tf$/"
+        "/^default_request_adder.tf$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?version = \"(?<currentValue>.+?)\"\\s"

--- a/vars.tf
+++ b/vars.tf
@@ -297,3 +297,9 @@ variable "backup_retention" {
   default     = 90
   description = "Backup retention of etcd data in days"
 }
+
+variable "default_request_adder_excluded_namespaces" {
+  type        = list(string)
+  default     = []
+  description = "Namespaces that should be excluded by default request adder (kube-system is always excluded), use * to disable (https://gitlab.com/unboundsoftware/default-request-adder)"
+}


### PR DESCRIPTION
Introduce a new local variable for default_request_adder that 
generates its content based on excluded namespaces. Add 
default_request_adder_excluded_namespaces variable to 
allow users to specify which namespaces to ignore. Update 
the related YAML configuration to manage permissions better 
and use the latest image version.