### PR TITLE
ci: add custom manager for regex version updates

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -40,7 +40,8 @@ locals {
   ] : [])
 
   default_request_adder = {
-    name    = "default_request_adder"
+    name = "default_request_adder"
+    # renovate: datasource=gitlab-releases depName=unboundsoftware/default-request-adder
     version = "1.0"
     content = file("${path.module}/addons/default-request-adder.yaml")
   }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>opzkit/renovate-config"
+  ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      ".+\\.yaml$/"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update version variables in tf-files",
+      "managerFilePatterns": [
+        "/^outputs.tf$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?version = \"(?<currentValue>.+?)\"\\s"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Adds a custom manager configuration in `renovate.json` for 
updating version variables in Terraform files. Expands Kubernetes 
manager file patterns to include YAML files. Updates `locals.tf` 
with a new comment indicating the use of GitLab releases as a 
data source for the `default_request_adder` version.