### PR TITLE
fix: correct regex pattern for kubernetes managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "kubernetes": {
     "managerFilePatterns": [
-      ".+\\.yaml$/"
+      "/.+\\.yaml$/"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
Update the regex pattern in the renovate.json file to ensure it 
accurately matches YAML files. The change adds a leading slash 
to the regex for improved pattern matching consistency.