### PR TITLE
fix: update version and file references for default request adder

### DIFF
--- a/addons/default-request-adder.yaml
+++ b/addons/default-request-adder.yaml
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: "50Mi"
           imagePullPolicy: Always
-          image: registry.gitlab.com/unboundsoftware/default-request-adder:1.0@sha256:1a57dcea1e8ea05f4e4b8ea325720f9d456a7b23a56064adcf91f1c04616d038
+          image: registry.gitlab.com/unboundsoftware/default-request-adder:1.1.4
           args:
             - /default-request-adder
             - -excluded-ns=kube-system

--- a/locals.tf
+++ b/locals.tf
@@ -42,7 +42,7 @@ locals {
   default_request_adder = {
     name = "default_request_adder"
     # renovate: datasource=gitlab-releases depName=unboundsoftware/default-request-adder
-    version = "1.0"
+    version = "1.1.4"
     content = file("${path.module}/addons/default-request-adder.yaml")
   }
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "customType": "regex",
       "description": "Update version variables in tf-files",
       "managerFilePatterns": [
-        "/^outputs.tf$/"
+        "/^locals.tf$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?version = \"(?<currentValue>.+?)\"\\s"


### PR DESCRIPTION
Updates the managerFilePatterns in renovate.json to reference 
locals.tf instead of outputs.tf. Modifies the image version in 
addons/default-request-adder.yaml and updates the version 
in locals.tf to match the new image version, ensuring compatibility 
with the latest release of the default request adder.