### PR TITLE
feat: add package rules for default-request-adder grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,15 @@
       "/.+\\.yaml$/"
     ]
   },
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "unboundsoftware/default-request-adder",
+        "registry.gitlab.com/unboundsoftware/default-request-adder"
+      ],
+      "groupName": "default-request-adder"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Adds package rules to group the dependencies 
"unboundsoftware/default-request-adder" and 
"registry.gitlab.com/unboundsoftware/default-request-adder".
This improves dependency management and 
streamlines updates through Renovate.