### PR TITLE
feat: extract hardcoded Cilium configuration to variable

### DIFF
--- a/cilium.tftest.hcl
+++ b/cilium.tftest.hcl
@@ -1,0 +1,104 @@
+mock_provider "aws" {}
+mock_provider "kops" {}
+mock_provider "null" {}
+
+variables {
+  name = "test-cluster"
+  bucket_state_store = {
+    id  = "test-bucket"
+    arn = "arn:aws:s3:::test-bucket"
+  }
+  region             = "eu-west-1"
+  vpc_id             = "vpc-123"
+  dns_zone           = "test.example.com"
+  kubernetes_version = "1.31.0"
+  iam_role_mappings  = {}
+  public_subnets = {
+    a = { cidr_block = "10.0.1.0/24", id = "subnet-a" }
+    b = { cidr_block = "10.0.2.0/24", id = "subnet-b" }
+    c = { cidr_block = "10.0.3.0/24", id = "subnet-c" }
+  }
+}
+
+run "cilium_defaults" {
+  command = plan
+
+  variables {
+    networking_cni = "cilium"
+  }
+
+  assert {
+    condition     = var.cilium.enable_remote_node_identity == true
+    error_message = "Expected enable_remote_node_identity to default to true"
+  }
+
+  assert {
+    condition     = var.cilium.preallocate_bpf_maps == true
+    error_message = "Expected preallocate_bpf_maps to default to true"
+  }
+
+  assert {
+    condition     = var.cilium.enable_node_port == true
+    error_message = "Expected enable_node_port to default to true"
+  }
+
+  assert {
+    condition     = var.cilium.enable_prometheus_metrics == true
+    error_message = "Expected enable_prometheus_metrics to default to true"
+  }
+}
+
+run "cilium_overrides" {
+  command = plan
+
+  variables {
+    networking_cni = "cilium"
+    cilium = {
+      enable_remote_node_identity = false
+      preallocate_bpf_maps        = false
+      enable_node_port            = false
+      enable_prometheus_metrics   = false
+    }
+  }
+
+  assert {
+    condition     = var.cilium.enable_remote_node_identity == false
+    error_message = "Expected enable_remote_node_identity to be overridable"
+  }
+
+  assert {
+    condition     = var.cilium.preallocate_bpf_maps == false
+    error_message = "Expected preallocate_bpf_maps to be overridable"
+  }
+
+  assert {
+    condition     = var.cilium.enable_node_port == false
+    error_message = "Expected enable_node_port to be overridable"
+  }
+
+  assert {
+    condition     = var.cilium.enable_prometheus_metrics == false
+    error_message = "Expected enable_prometheus_metrics to be overridable"
+  }
+}
+
+run "cilium_partial_override" {
+  command = plan
+
+  variables {
+    networking_cni = "cilium"
+    cilium = {
+      enable_prometheus_metrics = false
+    }
+  }
+
+  assert {
+    condition     = var.cilium.enable_remote_node_identity == true
+    error_message = "Expected unspecified fields to retain defaults"
+  }
+
+  assert {
+    condition     = var.cilium.enable_prometheus_metrics == false
+    error_message = "Expected enable_prometheus_metrics to be overridable"
+  }
+}

--- a/cilium_hubble.tftest.hcl
+++ b/cilium_hubble.tftest.hcl
@@ -28,7 +28,7 @@ run "hubble_disabled_by_default" {
   }
 
   assert {
-    condition     = var.cilium_hubble.enabled == false
+    condition     = var.cilium.hubble.enabled == false
     error_message = "Expected hubble to be disabled by default"
   }
 }
@@ -38,13 +38,15 @@ run "hubble_enabled_with_cilium" {
 
   variables {
     networking_cni = "cilium"
-    cilium_hubble = {
-      enabled = true
+    cilium = {
+      hubble = {
+        enabled = true
+      }
     }
   }
 
   assert {
-    condition     = var.cilium_hubble.enabled == true
+    condition     = var.cilium.hubble.enabled == true
     error_message = "Expected hubble to be enabled"
   }
 }
@@ -54,14 +56,16 @@ run "hubble_default_metrics" {
 
   variables {
     networking_cni = "cilium"
-    cilium_hubble = {
-      enabled = true
+    cilium = {
+      hubble = {
+        enabled = true
+      }
     }
   }
 
   assert {
-    condition     = length(var.cilium_hubble.metrics) == 9
-    error_message = "Expected 9 default metrics, got ${length(var.cilium_hubble.metrics)}"
+    condition     = length(var.cilium.hubble.metrics) == 9
+    error_message = "Expected 9 default metrics, got ${length(var.cilium.hubble.metrics)}"
   }
 }
 
@@ -70,15 +74,17 @@ run "hubble_custom_metrics" {
 
   variables {
     networking_cni = "cilium"
-    cilium_hubble = {
-      enabled = true
-      metrics = ["dns", "drop"]
+    cilium = {
+      hubble = {
+        enabled = true
+        metrics = ["dns", "drop"]
+      }
     }
   }
 
   assert {
-    condition     = length(var.cilium_hubble.metrics) == 2
-    error_message = "Expected 2 custom metrics, got ${length(var.cilium_hubble.metrics)}"
+    condition     = length(var.cilium.hubble.metrics) == 2
+    error_message = "Expected 2 custom metrics, got ${length(var.cilium.hubble.metrics)}"
   }
 }
 
@@ -87,8 +93,10 @@ run "hubble_with_calico_fails" {
 
   variables {
     networking_cni = "calico"
-    cilium_hubble = {
-      enabled = true
+    cilium = {
+      hubble = {
+        enabled = true
+      }
     }
   }
 
@@ -105,7 +113,7 @@ run "hubble_disabled_with_calico_succeeds" {
   }
 
   assert {
-    condition     = var.cilium_hubble.enabled == false
+    condition     = var.cilium.hubble.enabled == false
     error_message = "Expected hubble to be disabled"
   }
 }

--- a/k8s.tf
+++ b/k8s.tf
@@ -125,10 +125,10 @@ resource "kops_cluster" "k8s" {
         enable_prometheus_metrics   = var.cilium.enable_prometheus_metrics
 
         dynamic "hubble" {
-          for_each = var.cilium_hubble.enabled ? [1] : []
+          for_each = var.cilium.hubble.enabled ? [1] : []
           content {
             enabled = true
-            metrics = var.cilium_hubble.metrics
+            metrics = var.cilium.hubble.metrics
           }
         }
       }

--- a/k8s.tf
+++ b/k8s.tf
@@ -119,10 +119,10 @@ resource "kops_cluster" "k8s" {
     dynamic "cilium" {
       for_each = local.allowed_cnis["cilium"]
       content {
-        enable_remote_node_identity = true
-        preallocate_bpf_maps        = true
-        enable_node_port            = true
-        enable_prometheus_metrics   = true
+        enable_remote_node_identity = var.cilium.enable_remote_node_identity
+        preallocate_bpf_maps        = var.cilium.preallocate_bpf_maps
+        enable_node_port            = var.cilium.enable_node_port
+        enable_prometheus_metrics   = var.cilium.enable_prometheus_metrics
 
         dynamic "hubble" {
           for_each = var.cilium_hubble.enabled ? [1] : []

--- a/locals.tf
+++ b/locals.tf
@@ -214,7 +214,7 @@ resource "null_resource" "cni_check" {
 resource "null_resource" "hubble_requires_cilium" {
   lifecycle {
     precondition {
-      condition     = !var.cilium_hubble.enabled || var.networking_cni == "cilium"
+      condition     = !var.cilium.hubble.enabled || var.networking_cni == "cilium"
       error_message = "Hubble requires networking_cni to be 'cilium'."
     }
   }

--- a/vars.tf
+++ b/vars.tf
@@ -214,6 +214,17 @@ variable "networking_cni" {
   description = "Which CNI provider to use, supported values are 'calico' and 'cilium'"
 }
 
+variable "cilium" {
+  type = object({
+    enable_remote_node_identity = optional(bool, true)
+    preallocate_bpf_maps        = optional(bool, true)
+    enable_node_port            = optional(bool, true)
+    enable_prometheus_metrics   = optional(bool, true)
+  })
+  default     = {}
+  description = "Cilium CNI configuration. Only applied when networking_cni is 'cilium'."
+}
+
 variable "cilium_hubble" {
   type = object({
     enabled = optional(bool, false)

--- a/vars.tf
+++ b/vars.tf
@@ -220,21 +220,17 @@ variable "cilium" {
     preallocate_bpf_maps        = optional(bool, true)
     enable_node_port            = optional(bool, true)
     enable_prometheus_metrics   = optional(bool, true)
-  })
-  default     = {}
-  description = "Cilium CNI configuration. Only applied when networking_cni is 'cilium'."
-}
-
-variable "cilium_hubble" {
-  type = object({
-    enabled = optional(bool, false)
-    metrics = optional(list(string), ["dns", "drop", "flow", "flows-to-world", "httpV2", "icmp", "kafka", "port-distribution", "tcp"])
+    hubble = optional(object({
+      enabled = optional(bool, false)
+      metrics = optional(list(string), ["dns", "drop", "flow", "flows-to-world", "httpV2", "icmp", "kafka", "port-distribution", "tcp"])
+    }), {})
   })
   default     = {}
   description = <<-EOT
-    Hubble observability configuration for Cilium. Requires networking_cni to be 'cilium'.
-    Valid metric values: dns, drop, flow, flows-to-world, httpV2, icmp, kafka, port-distribution, tcp.
-    Metrics can include options separated by semicolons, e.g. "dns:query;ignoreAAAA" or "httpV2:exemplars=true;labelsContext=source_ip".
+    Cilium CNI configuration. Only applied when networking_cni is 'cilium'.
+    hubble: Hubble observability configuration. Requires networking_cni to be 'cilium'.
+      Valid metric values: dns, drop, flow, flows-to-world, httpV2, icmp, kafka, port-distribution, tcp.
+      Metrics can include options separated by semicolons, e.g. "dns:query;ignoreAAAA" or "httpV2:exemplars=true;labelsContext=source_ip".
   EOT
 }
 


### PR DESCRIPTION
## Summary
- Add a new `cilium` object variable that exposes the four Cilium CNI settings previously hardcoded in `k8s.tf` (`enable_remote_node_identity`, `preallocate_bpf_maps`, `enable_node_port`, `enable_prometheus_metrics`). All fields are optional and default to `true`, matching the previous hardcoded values.
- Fold the existing `cilium_hubble` variable into `cilium.hubble` so all Cilium-related config lives under a single object.
- Add `cilium.tftest.hcl` covering defaults, full overrides, and partial overrides; update `cilium_hubble.tftest.hcl` to use the nested structure.

## Breaking change

The top-level `cilium_hubble` variable has been removed. Move its value under `cilium.hubble`:

```hcl
# Before
cilium_hubble = {
  enabled = true
  metrics = ["dns", "drop"]
}

# After
cilium = {
  hubble = {
    enabled = true
    metrics = ["dns", "drop"]
  }
}
```

Defaults are unchanged, so callers that did not set `cilium_hubble` need no migration.

## Test plan
- [x] `terraform test` — all 23 tests pass (including updated hubble tests)
- [x] `terraform fmt` clean
- [x] `prek run` (pre-commit) passes