### PR TITLE
fix(auth): drop stray brace in aws-iam-authenticator username template

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -212,7 +212,7 @@ resource "kops_cluster" "k8s" {
         for_each = var.iam_role_mappings
         content {
           arn      = identity_mappings.key
-          username = "role:{{SessionName}}}"
+          username = "role:{{SessionName}}"
           groups   = [identity_mappings.value]
         }
       }


### PR DESCRIPTION
The CRD identity mapping rendered `username` as `role:{{SessionName}}}` — the third brace is literal, so an assumed-role session resolves to `role:<session>}` (e.g. `role:rickard-fredriksson}`) in `kubectl auth whoami` and Forbidden errors.

**Cosmetic only.** RBAC binds on the `groups` field, not the username, so authorization is unaffected. The trailing brace is just confusing in whoami output and audit logs.

Fix: `role:{{SessionName}}}` → `role:{{SessionName}}`.