### PR TITLE
feat: update cluster-autoscaler module to v1.36.0

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -457,7 +457,7 @@ data "aws_security_group" "nodes" {
 }
 
 module "cluster_autoscaler" {
-  source       = "git::https://github.com/opzkit/terraform-aws-k8s-addons-cluster-autoscaler.git?ref=v1.35.1"
+  source       = "git::https://github.com/opzkit/terraform-aws-k8s-addons-cluster-autoscaler.git?ref=v1.36.0"
   replicas     = local.min_number_of_nodes > 1 ? 2 : 1
   cluster_name = var.name
 }


### PR DESCRIPTION
Bumps `terraform-aws-k8s-addons-cluster-autoscaler` from `v1.35.1` to `v1.36.0`.

That release adds a cluster-autoscaler `1.36.1` addon entry gated on `>=1.36.0` — without it, Kubernetes 1.36 clusters matched only the `>=1.35.0` entry and ran cluster-autoscaler 1.35. It also bumps the 1.33/1.34/1.35 entries to their latest patch releases (1.33.6 / 1.34.5 / 1.35.2).

The kops provider constraint here (`>= 1.34.4`) already permits 1.36.0, so no other change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvfpBZckEM9XkxL46i8v5s
