### PR TITLE
feat: expose file_assets on the cluster

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -288,6 +288,16 @@ resource "kops_cluster" "k8s" {
   }
 
   dynamic "file_assets" {
+    for_each = var.file_assets
+    content {
+      name    = file_assets.value.name
+      path    = file_assets.value.path
+      content = file_assets.value.content
+      roles   = file_assets.value.roles
+    }
+  }
+
+  dynamic "file_assets" {
     for_each = var.node_cloudwatch_logging.enabled ? [1] : []
     content {
       name = "cloudwatch-agent-config"

--- a/vars.tf
+++ b/vars.tf
@@ -264,6 +264,17 @@ variable "containerd_config_additions" {
   default     = {}
 }
 
+variable "file_assets" {
+  type = list(object({
+    name    = string
+    path    = string
+    content = string
+    roles   = optional(list(string))
+  }))
+  default     = []
+  description = "Files to write on the nodes, see https://kops.sigs.k8s.io/cluster_spec/#file-assets. Roles defaults to all roles."
+}
+
 variable "registry_mirrors" {
   type        = map(list(string))
   description = "Registry mirrors for containerd - maps registry to list of mirror endpoints"


### PR DESCRIPTION
Adds a `file_assets` variable so consumers can write arbitrary files onto nodes via the kOps cluster spec.

**Why now:** kOps 1.36 moved containerd registry mirrors out of `config.toml` and into `/etc/containerd/certs.d/<registry>/hosts.toml` (`buildRegistryHosts`, `nodeup/pkg/model/containerd.go`). It emits only `capabilities`, never `override_path = true`. containerd then appends `/v2` to any host path that does not already end in `/v2` (`core/remotes/docker/config/hosts.go:441`):

```go
if !strings.HasSuffix(u.Path, "/v2") && !config.OverridePath {
    u.Path = u.Path + "/v2"
}
```

For an ECR pull-through cache the mirror endpoint is `https://<acct>.dkr.ecr.<region>.amazonaws.com/v2/<prefix>`, which already carries the API root, so requests become `/v2/<prefix>/v2/<repo>/manifests/...` and ECR answers 403. kOps ≤1.35 wrote the deprecated inline `registry.mirrors` block, which used the endpoint path verbatim, so this worked before.

kOps exposes no knob for `override_path`. With `file_assets` a consumer can write its own hosts.toml and repoint `registry.config_path` at it through the existing `containerd_config_additions`.

`roles` is optional and defaults to all roles, matching kOps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvfpBZckEM9XkxL46i8v5s
